### PR TITLE
Add default focus to search-form

### DIFF
--- a/src/javascripts/emoty.js
+++ b/src/javascripts/emoty.js
@@ -945,10 +945,9 @@ Emoty.emojisIndex = (function(){
   $.each(Emoty.emojis, function(k, v){
     merged = merged.concat(v);
   });
-  merged.sort();
 
   var index = {};
-  $.each(merged, function(k, v){
+  $.each(merged, function(i, v){
     index[v] = Emoty.convertImageIdForHtml(v);
   });
 

--- a/src/javascripts/popup.js
+++ b/src/javascripts/popup.js
@@ -48,4 +48,10 @@ $(function() {
             };
         });
     });
+
+    // Default focus setting
+    // ref) http://stackoverflow.com/questions/9646772/chrome-extension-popup-textarea-focus
+    setTimeout(function(){
+        $('#header .searcher input').focus();
+    }, 500);
 });

--- a/src/stylesheets/popup.css
+++ b/src/stylesheets/popup.css
@@ -13,6 +13,10 @@ body {
   position: relative;
 }
 
+#header > p > a {
+  outline: none;
+}
+
 #header .searcher {
   margin: 0 auto;
   width: 530px;


### PR DESCRIPTION
- 起動時に、検索フォームにフォーカスさせるようにした
- 元々その上にあるアンカーにフォーカス枠が出てて、今回の改修でそれが移動してしまうのが変だったので、アンカーの枠をCSSで消した
- setTimeout で 500ms 間隔を置いて移動しているのは、ハック的な対処。他に方法が見つからなかった。Chromeの重さ次第では動かないこともある

フォーカスしなくてもいい気はしている
