### PR TITLE
Show icons by shifting the timing for each category

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "grunt-contrib-compress": "~0.7.0",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-sass": "~0.9.2",
     "grunt-haml": "~0.9.0",
     "grunt": "~0.4.4",
     "grunt-yaml": "~0.4.0"

--- a/src/javascripts/popup.coffee
+++ b/src/javascripts/popup.coffee
@@ -1,4 +1,7 @@
 $ ->
+  contentTiming = 100
+  delay = 700
+
   $.each window.emoticons, (_, category) ->
     $('#category-nav').append """
       <li>#{category.name}</li>
@@ -12,22 +15,26 @@ $ ->
         .text category.name
     )
 
-    $.each category.emoticons, (_, emoticon) ->
-      content.append(
-        $('<img>')
-          .attr
-            src:   "images/emoticons/#{emoticon}.png"
-            class: 'emoticon'
-            alt:    emoticon
-          .data emoticon: ":#{emoticon}:"
-      )
+    setTimeout ->
+      $.each category.emoticons, (_, emoticon) ->
+        content.append(
+          $('<img>')
+            .attr
+              src:   "images/emoticons/#{emoticon}.png"
+              class: 'emoticon'
+              alt:    emoticon
+            .data emoticon: ":#{emoticon}:"
+        )
+    , contentTiming
+
+    contentTiming += delay
 
     $('#emoticons').append content
 
-  $('#emoticons img')
-    .on 'click', ->
+  $(document)
+    .on 'click', '#emoticons img', ->
       Emoty.copy $(@).data('emoticon')
-    .on 'mouseenter', ->
+    .on 'mouseenter', '#emoticons img', ->
       do ($ '.title').hide
 
       ($ '.notice')
@@ -35,7 +42,7 @@ $ ->
         .append """
           <p>#{$(@).data('emoticon')}</p>
         """
-    .on 'mouseleave', ->
+    .on 'mouseleave', '#emoticons img', ->
       do $('.title').show
 
       $('.notice')

--- a/src/popup.haml
+++ b/src/popup.haml
@@ -4,10 +4,6 @@
     %meta(charset='utf-8')
     %title Emoty
     %link(rel='stylesheet' href='stylesheets/popup.css')
-    %script(src='javascripts/jquery.js')
-    %script(src='javascripts/emoticons.js')
-    %script(src='javascripts/emoty.js')
-    %script(src='javascripts/popup.js')
   %body
     %header
       .notice
@@ -22,3 +18,8 @@
     %ul#category-nav
 
     #emoticons
+
+    %script(src='javascripts/jquery.js')
+    %script(src='javascripts/emoticons.js')
+    %script(src='javascripts/emoty.js')
+    %script(src='javascripts/popup.js')


### PR DESCRIPTION
便利に使用させていただいています。
ポップアップの表示に時間がかかるのが気になったので、 #6 について対応しました。

ポップアップを表示する時に、一度にアイコンを表示しようとして詰まっているようでしたので、ポップアップを先に表示させつつ、カテゴリごとアイコンを表示するタイミングをずらすようにしました。

私の環境ではだいぶ快適になりましたが、スペックの異なる環境で確認できていないのと、全てのアイコンが表示されるまで若干時間が必要になるのが許容されるかが心配です :sweat_smile:

よろしければ確認していただけると幸いです！ :bow: 